### PR TITLE
Fix find observables from array of children

### DIFF
--- a/src/karet.js
+++ b/src/karet.js
@@ -298,8 +298,13 @@ class FromClass extends LiftedComponent {
 
 function hasAnyObs(props, args) {
   for (let i=2, n=args.length; i<n; ++i)
-    if (isObs(args[i]))
-      return true
+    if (Array.isArray(args[i])) {
+      for (let j=0, m=args[i].length; j<m; ++j)
+        if (isObs(args[i][j]))
+          return true
+    } else
+      if (isObs(args[i]))
+        return true
   return hasObs(args[1])
 }
 


### PR DESCRIPTION
If you pass multiple children to a custom component, the resulting `createElement` call for for the built-in component (`div` in this case) will pass the children as an array.

```js
const CustomComponent = ({children}) => <div>{children}</div>
const Test = <CustomComponent>{obsA}{obsB}</CustomComponent>
```

Results in:
```js
var CustomComponent = function CustomComponent(_ref) {
  var children = _ref.children;
  return React.createElement(
    "div",
    null,
    children
  );
};

var Test = React.createElement(
  CustomComponent,
  null,
  obsA,
  obsB
);
```

karet expected the children to be present in `createElement` arguments 2..n, and if there was an array of children in argument 2, it would not find the observables if there was any included in the children, thus resulting in using React's own createElement, which errors if given observables.

This fix will properly look for observables also in array of children.