### PR TITLE
detect observables properly when children are passed as part of props…

### DIFF
--- a/src/karet.js
+++ b/src/karet.js
@@ -93,6 +93,14 @@ function hasObs(props) {
     const val = props[key]
     if (isObs(val)) {
       return true
+    } else if (CHILDREN === key) {
+      if (isArray(val)) {
+        for (let i=0, n=val.length; i<n; ++i) {
+          const valI = val[i]
+          if (isObs(valI))
+            return true
+        }
+      }
     } else if (STYLE === key) {
       for (const k in val) {
         const valK = val[k]

--- a/test/tests.js
+++ b/test/tests.js
@@ -64,6 +64,13 @@ describe("basics", () => {
 
   testRender(<Custom karet-lift prop={"lifted anyway"} ref="test"/>,
              '<div>lifted anyway {}</div>')
+
+  const Spread = props => <div {...props} />
+
+  testRender(<Spread>
+               Hello {Kefir.constant("world!")}
+             </Spread>,
+             '<div>Hello world!</div>')
 })
 
 describe("fromKefir", () => {


### PR DESCRIPTION
… argument to createElement

Right now karet assumes that children are always passed in `React.createElement(type, props, [...children])`'s argument `children`, however it is also possible that children are passed in the props object. For example if you take `props` as an argument for a component and then spread that as a whole to another component:

```js
const Test = (props) => <div {...props} />

const x = <Test>Hello {Kefir.constant('world')}</Test>
```

This will yield, when transpiled, in:

```js
var Test = function Test(props) {
  return React.createElement('div', props);
};

var x = React.createElement(
  Test,
  null,
  'Hello ',
  Kefir.constant('world')
);
```

If children is just a single element, karet will actually work properly, but in case children is an array, like in this example, karet will fail to detect the observable in the array.

This PR addresses the issue.