### PR TITLE
Moved kefir to peerDependencies:

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "eslint": "^3.15.0",
     "eslint-plugin-babel": "^4.0.1",
     "eslint-plugin-react": "^6.9.0",
+    "kefir": "^3.7.0",
     "mocha": "^3.2.0",
     "nyc": "^10.1.2",
     "react-addons-test-utils": "^15.4.2",
@@ -46,7 +47,9 @@
   },
   "dependencies": {
     "infestines": "^0.4.1",
-    "kefir": "^3.2.1",
     "react": "^15.0.1"
+  },
+  "peerDependencies": {
+    "kefir": "^3.7.0"
   }
 }


### PR DESCRIPTION
- In order to ensure only one version of kefir is used within a project due to instanceof operations

We were running into issues where `instanceof Observable` operations were failing because of mismatching or multiple same versions (due to not doing empty npm install) of Kefir.

I moved `Kefir` to peerDependencies to ensure that Karet uses same Kefir module.