### PR TITLE
Use named export for `createElement`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ observables into VDOM has the following benefits:
     are pushed through observables.  An update to a deeply nested VDOM element
     can be an O(1) operation.
 
-Using Karet couldn't be simpler.  You just `import React from "karet"` and you
-are good to go.
+Using Karet couldn't be simpler.  You just `import * as React from "karet"` and
+you are good to go.
 
 [![npm version](https://badge.fury.io/js/karet.svg)](http://badge.fury.io/js/karet)
 [![Gitter](https://img.shields.io/gitter/room/calmm-js/chat.js.svg)](https://gitter.im/calmm-js/chat)
@@ -46,7 +46,7 @@ are good to go.
 To use Karet, you simply import it as `React`:
 
 ```jsx
-import React from "karet"
+import * as React from "karet"
 ```
 
 and you can then write React components:
@@ -61,7 +61,12 @@ const Clock = () =>
 ```
 
 with VDOM that can have embedded [Kefir](http://rpominov.github.io/kefir/)
-observables.
+observables.  This works because Karet exports an enhanced version of
+`createElement`.
+
+**NOTE:** Karet does not export other named React functions.  Only React
+lookalike `createElement` is exported, which is all that is needed for basic use
+of JSX.
 
 **NOTE:** The result, like the `Clock` above, is *just* a React component.  If
 you export it, you can use it just like any other React component and even in
@@ -77,8 +82,8 @@ on a non-primitive element instructs Karet to lift the element.
 For example, you could write:
 
 ```jsx
-import * as RR from "react-router"
-import React   from "karet"
+import * as RR    from "react-router"
+import * as React from "karet"
 
 const Link1 = ({...props}) => <RR.Link karet-lift {...props}/>
 ```

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ with VDOM that can have embedded [Kefir](http://rpominov.github.io/kefir/)
 observables.  This works because Karet exports an enhanced version of
 `createElement`.
 
-**NOTE:** Karet does not export other named React functions.  Only React
-lookalike `createElement` is exported, which is all that is needed for basic use
-of JSX.
+**NOTE:** Karet does not pass through other named React exports.  Only
+`createElement` is exported, which is all that is needed for basic use of VDOM
+or the Babel JSX transform.
 
 **NOTE:** The result, like the `Clock` above, is *just* a React component.  If
 you export it, you can use it just like any other React component and even in

--- a/src/karet.js
+++ b/src/karet.js
@@ -353,7 +353,7 @@ function filterProps(type, props) {
   return newProps
 }
 
-function createElement(...args) {
+export function createElement(...args) {
   const type = args[0]
   const props = args[1] || object0
   if (isString(type) || props[LIFT]) {
@@ -368,8 +368,8 @@ function createElement(...args) {
 }
 
 export default process.env.NODE_ENV === "production"
-  ? assocPartialU("createElement", createElement, React)
-  : Object.defineProperty(assocPartialU("createElement", createElement, dissocPartialU("PropTypes", React)), "PropTypes", {
+  ? /*#__PURE__*/assocPartialU("createElement", createElement, React)
+  : /*#__PURE__*/Object.defineProperty(assocPartialU("createElement", createElement, dissocPartialU("PropTypes", React)), "PropTypes", {
     get: (React => () => React.PropTypes)(React)
   })
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,6 +1,7 @@
 import * as Kefir from "kefir"
 
-import React, {fromClass, fromKefir} from "../dist/karet.cjs"
+import * as React from "../dist/karet.cjs"
+import {Component} from "react"
 import ReactDOM from "react-dom/server"
 import PropTypes from "prop-types"
 
@@ -88,11 +89,11 @@ describe("basics", () => {
 })
 
 describe("fromKefir", () => {
-  testRender(fromKefir(Kefir.constant(<p>Yes</p>)), '<p>Yes</p>')
+  testRender(React.fromKefir(Kefir.constant(<p>Yes</p>)), '<p>Yes</p>')
 })
 
 describe("fromClass", () => {
-  const P = fromClass("p")
+  const P = React.fromClass("p")
   testRender(<P $$ref={() => {}}>Hello</P>, '<p>Hello</p>')
 
   testRender(<P>Hello, {"world"}!</P>, '<p>Hello, world!</p>')
@@ -105,7 +106,7 @@ describe("fromClass", () => {
 })
 
 describe("context", () => {
-  class Context extends React.Component {
+  class Context extends Component {
     constructor(props) {
       super(props)
     }


### PR DESCRIPTION
The point of this is that allows a bundler like Rollup with UglifyJS to generate
smaller and faster bundles as the exported `createElement` function can be
referred to directly without using a module prefixed long name for it.