### PR TITLE
Fix rendering of `<Fragment>{U.sink(...)}</Fragment>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.2.1
+
+Changed rendering of children to replace `undefined` children with `null`
+children, because `React.Fragment` apparently does not like `undefined`
+children.
+
 ## 3.0.0
 
 Only Kefir properties, in other words, objects that inherit `Kefir.Property`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "karet",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -192,9 +192,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "9.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.5.tgz",
-      "integrity": "sha512-NOLEgsT6UiDTjnWG5Hd2Mg25LRyz/oe8ql3wbjzgSFeRzRROhPmtlsvIrei4B46UjERF0td9SZ1ZXPLOdcrBHg==",
+      "version": "9.6.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.6.tgz",
+      "integrity": "sha512-SJe0g5cZeGNDP5sD8mIX3scb+eq8LQQZ60FXiKZHipYSeEFZ5EKml+NNMiO76F74TY4PoMWlNxF/YRY40FOvZQ==",
       "dev": true
     },
     "acorn": {
@@ -6129,7 +6129,7 @@
       "dev": true,
       "requires": {
         "@types/estree": "0.0.38",
-        "@types/node": "9.6.5"
+        "@types/node": "9.6.6"
       }
     },
     "rollup-plugin-babel": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karet",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Karet is a library that allows you to embed Kefir properties into React VDOM",
   "module": "dist/karet.es.js",
   "main": "dist/karet.cjs.js",

--- a/src/karet.js
+++ b/src/karet.js
@@ -29,7 +29,8 @@ function renderChildren(children) {
   let newChildren = children
   for (let i = 0, n = children.length; i < n; ++i) {
     const v = children[i]
-    const w = isProperty(v) ? valueOf(v) : I.isArray(v) ? renderChildren(v) : v
+    let w = isProperty(v) ? valueOf(v) : I.isArray(v) ? renderChildren(v) : v
+    if (w === undefined) w = null
     if (v !== w) {
       if (newChildren === children) newChildren = children.slice(0)
       newChildren[i] = w
@@ -200,10 +201,10 @@ const FromClass = I.inherit(
         newArgs[0] = args[0]
         newArgs[1] = renderProps(args[1])
         for (let i = 2; i < n; ++i) {
-          const v = args[i]
-          newArgs[i] = isProperty(v)
-            ? valueOf(v)
-            : I.isArray(v) ? renderChildren(v) : v
+          let v = args[i]
+          v = isProperty(v) ? valueOf(v) : I.isArray(v) ? renderChildren(v) : v
+          if (v === undefined) v = null
+          newArgs[i] = v
         }
         return React.createElement.apply(null, newArgs)
       } else {


### PR DESCRIPTION
This works around the weird behaviour of `React.Fragment` on `undefined` children, which seems like a bug, because React explicitly handles `undefined` and boolean children in other contexts.