### PR TITLE
Passing through more React exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Using Karet couldn't be simpler.  Usually you just `import * as React from
 
 * [Tutorial](#tutorial)
 * [Reference](#reference)
-  * [`Fragment`](#Fragment)
+  * [React exports passed through](#react-exports-passed-through)
   * [`karet-lift` attribute](#karet-lift)
   * [`fromClass(Component)`](#fromClass "fromClass: Component props -> Component (Property props)")
 
@@ -59,26 +59,51 @@ with VDOM that can have embedded [Kefir](https://kefirjs.github.io/kefir/)
 properties.  This works because Karet exports an enhanced version of
 `createElement`.
 
+Note that the result, like the date and time display above, is *just* a React
+component.  If you export it, you can use it just like any other React component
+and even in modules that do not import `karet`.
+
 [Here is a live example in CodeSandbox](https://codesandbox.io/s/2o1mmnwxvp).
 
 [More links to live examples in the Calmm documentation
 Wiki](https://github.com/calmm-js/documentation/wiki/Links-to-live-examples).
 
-**NOTE:** Karet does not pass through all named React exports.  Only
-`createElement` and [`Fragment`](#Fragment) are exported, which is all that is
-needed for basic use of VDOM or the Babel JSX transform.
-
-**NOTE:** The result, like the date and time dispplay above, is *just* a React
-component.  If you export it, you can use it just like any other React component
-and even in modules that do not import `karet`.
-
 ## <a id="reference"></a> [≡](#contents) Reference
 
-### <a id="Fragment"></a> [≡](#contents) [`Fragment`](#Fragment)
+### <a id="react-exports-passed-through"></a> [≡](#contents) [React exports passed through](#react-exports-passed-through)
 
-In addition to `createElement`, Karet exports [React's `Fragment`
-component](https://reactjs.org/docs/fragments.html) and lifts fragments
-implicitly.
+Karet passes through the following exports from React:
+
+* [`Children`](https://reactjs.org/docs/react-api.html#reactchildren) as is.
+  Note that with observable properties in children these functions may not do
+  exactly what you want and you might want to
+  [lift](https://github.com/calmm-js/karet.util#lifting) them.
+* [`Fragment`](https://reactjs.org/docs/fragments.html) as is.  It should work
+  without problems.
+* [`createContext`](https://reactjs.org/docs/context.html#reactcreatecontext) as
+  is.  Note that with Karet it is preferable to put observable properties into
+  the context and let changes propagate through them rather than update the
+  context.
+* [`createElement`](https://reactjs.org/docs/react-api.html#createelement) which
+  lifts Kefir properties in [fragments](https://reactjs.org/docs/fragments.html)
+  and built-in HTML elements.
+* [`forwardRef`](https://reactjs.org/docs/react-api.html#reactforwardref) as is.
+
+Notably the following are not exported:
+
+* [`Component`](https://reactjs.org/docs/react-api.html#reactcomponent) and
+  [`PureComponent`](https://reactjs.org/docs/react-api.html#reactpurecomponent),
+  because with Karet you really don't need them and the `render` method can
+  cause undesired component remounting when used with observable properties
+  embedded into VDOM.
+* [`cloneElement`](https://reactjs.org/docs/react-api.html#cloneelement) does
+  not work out of the box with elements containing Kefir properties.  It should
+  be possible [to support it](https://github.com/calmm-js/karet/issues/6),
+  however.
+* [`createRef`](https://reactjs.org/docs/react-api.html#reactcreateref) is not
+  exported, because [Karet Util](https://github.com/calmm-js/karet.util)
+  provides an [alternative](https://github.com/calmm-js/karet.util/#U-refTo)
+  that works better with observable properties.
 
 ### <a id="karet-lift"></a> [≡](#contents) [`karet-lift` attribute](#karet-lift)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "karet",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karet",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "description": "Karet is a library that allows you to embed Kefir properties into React VDOM",
   "module": "dist/karet.es.js",
   "main": "dist/karet.cjs.js",
@@ -43,7 +43,7 @@
     "codecov": "^3.0.0",
     "concurrently": "^3.5.1",
     "eslint": "^4.19.1",
-    "eslint-plugin-babel": "^5.0.0",
+    "eslint-plugin-babel": "^5.1.0",
     "eslint-plugin-react": "^7.7.0",
     "kefir": "^3.8.3",
     "mocha": "^5.1.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -27,8 +27,10 @@ const build = ({NODE_ENV, format, suffix}) => ({
       include: 'node_modules/**',
       namedExports: {
         'node_modules/react/index.js': [
+          'Children',
           'Component',
           'Fragment',
+          'createContext',
           'createElement',
           'forwardRef'
         ]

--- a/src/karet.js
+++ b/src/karet.js
@@ -270,4 +270,4 @@ export const fromClass = type =>
 
 //
 
-export {Fragment} from 'react'
+export {Children, Fragment, createContext, forwardRef} from 'react'

--- a/test/tests.js
+++ b/test/tests.js
@@ -2,7 +2,6 @@ import * as Kefir from 'kefir'
 import * as L from 'partial.lenses'
 
 import * as React from '../dist/karet.cjs'
-import {createContext} from 'react'
 import ReactDOM from 'react-dom/server'
 
 function show(x) {
@@ -264,7 +263,7 @@ describe('simulated frontend', () => {
 })
 
 describe('context', () => {
-  const {Provider, Consumer} = createContext({})
+  const {Provider, Consumer} = React.createContext({})
 
   testRender(
     <Provider value={Kefir.constant('It is')}>


### PR DESCRIPTION
Pass through more React exports.

I would like to avoid passing through exports that don't work.  For example `cloneElement` is such an export and would need a replacement to work with elements that may have observable properties.  See #6.  I'm not opposed to supporting it in Karet, but I've never used it myself and I don't have infinite time...

* [x] What about `Children`?  Does it work well enough when children may contain observables?  Should functions in `Children` be lifted?

The primary goal is to pass through enough React exports that one almost never needs to import React.  Is this enough?