### PR TITLE
Configure github actions

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x, 16.x]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        cache: 'npm'
+        node-version: ${{ matrix.node-version }}
+
+    - name: Install node modules
+      run: npm ci
+
+    - name: Run tests
+      run: npm test


### PR DESCRIPTION
Runs tests on GitHub Actions. This does not remove travis since I believe it's used for coverage reporting and I believe it may have some secrets configured, but I am not certain about travis.

Tests are also not running on no longer supported node versions.